### PR TITLE
Microcks alternative to WireMock with OpenAPI contract test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <java.version>17</java.version>
         <awspring.version>3.1.0</awspring.version>
         <commons-io.version>1.3.2</commons-io.version>
-        <wiremock-testcontainers-module.version>1.0-alpha-13</wiremock-testcontainers-module.version>
+        <microcks-testcontainers-module.version>0.2.4</microcks-testcontainers-module.version>
         <spotless-maven-plugin.version>2.41.1</spotless-maven-plugin.version>
     </properties>
 
@@ -125,9 +125,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wiremock.integrations.testcontainers</groupId>
-            <artifactId>wiremock-testcontainers-module</artifactId>
-            <version>${wiremock-testcontainers-module.version}</version>
+            <groupId>io.github.microcks</groupId>
+            <artifactId>microcks-testcontainers</artifactId>
+            <version>${microcks-testcontainers-module.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/catalog-openapi.yaml
+++ b/src/main/resources/catalog-openapi.yaml
@@ -1,0 +1,96 @@
+openapi: 3.0.2
+info:
+  title: Catalog Service
+  version: 1.0
+  description: API definition of Catalog Service
+  license:
+    name: MIT License
+    url: https://opensource.org/licenses/MIT
+paths:
+  /api/products/{code}:
+    get:
+      parameters:
+        - name: code
+          description: product code
+          schema:
+            type: string
+          in: path
+          required: true
+          examples:
+            P101:
+              value: P101
+            P102:
+              value: P102
+            P103:
+              value: P103
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Product'
+              examples:
+                P101:
+                  value:
+                    id: 1
+                    code: P101
+                    name: Product P101
+                    description: Product P101 description
+                    imageUrl: null
+                    price: 34.0
+                    available: true
+                P102:
+                  value:
+                    id: 1
+                    code: P101
+                    name: Product P102
+                    description: Product P102 description
+                    imageUrl: null
+                    price: 25.0
+                    available: true
+                P103:
+                  value:
+                    id: 3
+                    code: P103
+                    name: Product P103
+                    description: Product P103 description
+                    imageUrl: null
+                    price: 15.0
+                    available: false
+components:
+  schemas:
+    Product:
+      title: Root Type for catalog Product
+      type: object
+      properties:
+        id:
+          description: Unique identifier of this product
+          type: number
+        code:
+          description: Code of this product
+          type: string
+        name:
+          description: Name of this product
+          type: string
+        description:
+          description: Description of this product
+          type: string
+        imageUrl:
+          description: Url of image of this product
+          type: string
+          nullable: true
+        price:
+          description: Price of this product
+          type: number
+        available:
+          description: Availability of this product
+          type: boolean
+      required:
+        - id
+        - code
+        - name
+        - description
+        - price
+        - imageUrl
+        - available
+      additionalProperties: false

--- a/step-1-getting-started.md
+++ b/step-1-getting-started.md
@@ -74,7 +74,7 @@ This might be helpful if the internet connection at the workshop venue is somewh
 ```shell
 docker pull postgres:16-alpine
 docker pull localstack/localstack:2.3
-docker pull wiremock/wiremock:3.2.0-alpine
+docker pull quay.io/microcks/microcks-uber:1.8.1
 docker pull confluentinc/cp-kafka:7.5.0
 docker pull confluentinc/cp-schema-registry:7.5.0
 docker pull confluentinc/cp-enterprise-control-center:7.5.0

--- a/step-2-exploring-the-app.md
+++ b/step-2-exploring-the-app.md
@@ -30,7 +30,7 @@ and `com.testcontainers.catalog.events.ProductEventListener`.
 
 ## External Service Integrations
 Our application talks to `inventory-service` to fetch the product availability information.
-We will use [WireMock](https://wiremock.org/) to mock the `inventory-service` during local development and testing.
+We will use [Microcks](https://microcks.io/) to mock the `inventory-service` during local development and testing.
 
 ## API Endpoints
 


### PR DESCRIPTION
This is a proposition of having Microcks as an alternative to WireMock
It shows:
* How to instantiate the Microcks testcontainers module as a Bean
* How to use Microcks for automating OpenAPI contract-tests for the ProductController

Signed-off-by: Laurent Broudoux <laurent.broudoux@gmail.com>